### PR TITLE
Fix for asctime calling mmap()

### DIFF
--- a/record-replay/fred.cpp
+++ b/record-replay/fred.cpp
@@ -120,6 +120,12 @@ static void recordReplayInit()
   char *login_name = getlogin();
   JASSERT(login_name != NULL);
 
+  /* asctime() causes the process to mmap()
+   * /usr/libXX/gconv/gconv-modules.cache into memory. Thus any later calls to
+   * asctime won't result in the mmap.
+   */
+  time_t t = time(NULL);
+  JASSERT(asctime(localtime(&t)) != NULL);
 
   JTRACE ( "Record/replay finished initializing." );
 }

--- a/record-replay/fred_read_log.cpp
+++ b/record-replay/fred_read_log.cpp
@@ -1132,6 +1132,8 @@ void initializeJalib()
   INIT_JALIB_FPTR(fclose);
 
   INIT_JALIB_FPTR(syscall);
+  INIT_JALIB_FPTR(mmap);
+  INIT_JALIB_FPTR(munmap);
 
   INIT_JALIB_FPTR(read);
   INIT_JALIB_FPTR(write);


### PR DESCRIPTION
asctime causes the process to mmap() /usr/libXX/gconv/gconv-modules.cache at runtime. This can interfere with other mmap routines and was causing a test fail.

This commit fixes this issue by calling asctime() during fred-initialization such that gconv-modules.cache is mmap()'d right then.

Also, minor fix for fred_read_log.
